### PR TITLE
Store vga code and font data in RAM, as flash is too slow

### DIFF
--- a/memory.x
+++ b/memory.x
@@ -25,11 +25,11 @@ MEMORY {
     /*
      * This is the bottom of the four striped banks of SRAM in the RP2040.
      */
-    RAM_OS : ORIGIN = 0x20000000, LENGTH = 0x3C000
+    RAM_OS : ORIGIN = 0x20000000, LENGTH = 0x3A000
     /*
      * This is the top of the four striped banks of SRAM in the RP2040.
      */
-    RAM : ORIGIN = 0x2003C000, LENGTH = 16K
+    RAM : ORIGIN = 0x2003A000, LENGTH = 24K
     /*
      * This is the fifth bank, a 4KB block. We use this for Core 0 Stack.
      */

--- a/src/main.rs
+++ b/src/main.rs
@@ -1545,6 +1545,7 @@ extern "C" fn time_ticks_per_second() -> common::Ticks {
 /// Called when DMA raises IRQ0; i.e. when a DMA transfer to the pixel FIFO or
 /// the timing FIFO has completed.
 #[interrupt]
+#[link_section = ".data"]
 fn DMA_IRQ_0() {
 	unsafe {
 		vga::irq();

--- a/src/vga/font16.rs
+++ b/src/vga/font16.rs
@@ -36,6 +36,7 @@ pub static FONT: super::Font = super::Font {
 };
 
 /// Our font data - arranged as 256 glyphs of 1 byte/row x 16 row/glyph.
+#[link_section = ".data"]
 static DATA: [u8; 256 * 16] = [
 	// Char::Null
 	0b0000_0000,

--- a/src/vga/font8.rs
+++ b/src/vga/font8.rs
@@ -38,6 +38,7 @@ pub static FONT: super::Font = super::Font {
 };
 
 /// Our font data - arranged as 256 glyphs of 1 byte/row x 8 row/glyph.
+#[link_section = ".data"]
 static DATA: [u8; 256 * 8] = [
 	// Char::Null
 	0b0000_0000,

--- a/src/vga/mod.rs
+++ b/src/vga/mod.rs
@@ -693,6 +693,7 @@ pub fn get_num_scan_lines() -> u16 {
 /// # Safety
 ///
 /// Only run this function on Core 1.
+#[link_section = ".data"]
 unsafe extern "C" fn core1_main() -> u32 {
 	CORE1_START_FLAG.store(true, Ordering::Relaxed);
 
@@ -721,6 +722,7 @@ unsafe extern "C" fn core1_main() -> u32 {
 /// # Safety
 ///
 /// Only call this from the DMA IRQ handler.
+#[link_section = ".data"]
 pub unsafe fn irq() {
 	let dma: &mut super::pac::DMA = match DMA_PERIPH.as_mut() {
 		Some(dma) => dma,
@@ -813,6 +815,7 @@ impl RenderEngine {
 		}
 	}
 
+	#[link_section = ".data"]
 	pub fn poll(&mut self) {
 		if DMA_READY.load(Ordering::Relaxed) {
 			DMA_READY.store(false, Ordering::Relaxed);


### PR DESCRIPTION
It looks like the pixel generating loop is nearly exhausting the time budget, and there is no margin left for flash cache misses.

I had to increase the RAM reserved for the BIOS from 16k to 24k. This might be excessive. Perhaps it is possibe to extract a smaller selection of really timing critical code and move only that to RAM?