### PR TITLE
Increase core0 stack to 8K and paint/measure stack usage.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,8 +2,7 @@
 # This will make a UF2 and copy it to the RP2040's Mass Storage Device bootloader
 # runner = "elf2uf2-rs -d"
 # This will flash over SWD with any compatible probe it finds. You need 0.3.1 or higher for RP2040 support.
-runner = "probe-run --chip RP2040 --measure-stack"
-
+runner = "probe-run --chip RP2040"
 rustflags = [
   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
   # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
@@ -17,4 +16,4 @@ rustflags = [
 ]
 
 [build]
-target = "thumbv6m-none-eabi"        # Cortex-M0 and Cortex-M0+
+target = "thumbv6m-none-eabi" # Cortex-M0 and Cortex-M0+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,3 +77,6 @@ lto = true
 # good choice for performance on the RP2040, where code executes from external
 # SPI Flash and has to be buffered in a small on-chip cache memory.
 opt-level = "s"
+
+[features]
+check-stack = []

--- a/memory.x
+++ b/memory.x
@@ -25,39 +25,14 @@ MEMORY {
     /*
      * This is the bottom of the four striped banks of SRAM in the RP2040.
      */
-    RAM_OS : ORIGIN = 0x20000000, LENGTH = 0x39000
+    RAM_OS : ORIGIN = 0x20000000, LENGTH = 232K
     /*
-     * This is the top of the four striped banks of SRAM in the RP2040.
+     * This is the top of the four striped banks of SRAM in the RP2040, plus SRAM_BANK4 and SRAM_BANK5.
      *
-     * We give ourselves size 4K pages [0x39_000..0x3E_FFF]
+     * We give ourselves eight 4K pages [0x3A_000..0x41_FFF]
      */
-    RAM : ORIGIN = 0x20039000, LENGTH = 24K
-    /*
-     * This 4K from the top of striped RAM, plus the fifth bank - another a 4KB
-     * block. We use this for Core 0 Stack. We tried 4K but it wasn't enough.
-     */
-    RAM_CORE0_STACK : ORIGIN = 0x2003F000, LENGTH = 8K
-    /*
-     * This is the sixth bank, a 4KB block. We use this for Core 1 Stack.
-     * As of 0.5.1 Pico BIOS uses about 316 bytes of this but we give it the
-     * full 4K so it can have uncontended access to this SRAM bank.
-     */
-    RAM_CORE1_STACK : ORIGIN = 0x20041000, LENGTH = 4K
+    RAM : ORIGIN = 0x2003A000, LENGTH = 32K
 }
-
-/*
- * This is where the call stack for Core 0 will be located. The stack is of
- * the full descending type.
- */
-_stack_start = ORIGIN(RAM_CORE0_STACK) + LENGTH(RAM_CORE0_STACK);
-_stack_bottom = ORIGIN(RAM_CORE0_STACK);
-_stack_len = LENGTH(RAM_CORE0_STACK);
-
-/*
- * This is where the call stack for Core 1 will be located.
- */
-_core1_stack_bottom = ORIGIN(RAM_CORE1_STACK);
-_core1_stack_len = LENGTH(RAM_CORE1_STACK);
 
 /*
  * Export some symbols to tell the BIOS where it might find the OS.

--- a/memory.x
+++ b/memory.x
@@ -25,30 +25,33 @@ MEMORY {
     /*
      * This is the bottom of the four striped banks of SRAM in the RP2040.
      */
-    RAM_OS : ORIGIN = 0x20000000, LENGTH = 0x3A000
+    RAM_OS : ORIGIN = 0x20000000, LENGTH = 0x39000
     /*
      * This is the top of the four striped banks of SRAM in the RP2040.
      *
-     * We give ourselves six 4K pages [0x3A_000, 0x40_000]
+     * We give ourselves size 4K pages [0x39_000..0x3E_FFF]
      */
-    RAM : ORIGIN = 0x2003A000, LENGTH = 24K
+    RAM : ORIGIN = 0x20039000, LENGTH = 24K
     /*
-     * This is the fifth bank, a 4KB block. We use this for Core 0 Stack.
+     * This 4K from the top of striped RAM, plus the fifth bank - another a 4KB
+     * block. We use this for Core 0 Stack. We tried 4K but it wasn't enough.
      */
-    RAM_CORE0_STACK : ORIGIN = 0x20040000, LENGTH = 4K
+    RAM_CORE0_STACK : ORIGIN = 0x2003F000, LENGTH = 8K
     /*
      * This is the sixth bank, a 4KB block. We use this for Core 1 Stack.
+     * As of 0.5.1 Pico BIOS uses about 316 bytes of this but we give it the
+     * full 4K so it can have uncontended access to this SRAM bank.
      */
     RAM_CORE1_STACK : ORIGIN = 0x20041000, LENGTH = 4K
 }
 
 /*
  * This is where the call stack for Core 0 will be located. The stack is of
- * the full descending type. You may want to use this variable to locate the
- * call stack and static variables in different memory regions. Below is
- * shown the default value
+ * the full descending type.
  */
 _stack_start = ORIGIN(RAM_CORE0_STACK) + LENGTH(RAM_CORE0_STACK);
+_stack_bottom = ORIGIN(RAM_CORE0_STACK);
+_stack_len = LENGTH(RAM_CORE0_STACK);
 
 /*
  * This is where the call stack for Core 1 will be located.

--- a/src/vga/mod.rs
+++ b/src/vga/mod.rs
@@ -1034,9 +1034,13 @@ pub fn init(
 		}
 		core::slice::from_raw_parts_mut(
 			&mut _core1_stack_bottom as *mut _,
-			&mut _core1_stack_len as *const _ as usize / 4,
+			&mut _core1_stack_len as *const _ as usize / core::mem::size_of::<usize>(),
 		)
 	};
+
+	for b in core1_stack.iter_mut() {
+		*b = super::CORE1_STACK_PAINT_WORD;
+	}
 
 	debug!(
 		"Core 1 stack: {:08x}, {} bytes",

--- a/src/vga/mod.rs
+++ b/src/vga/mod.rs
@@ -1027,25 +1027,16 @@ pub fn init(
 	// cannot be reconfigured at a later time, but they do keep on running
 	// as-is.
 
-	let core1_stack: &'static mut [usize] = unsafe {
-		extern "C" {
-			static mut _core1_stack_bottom: usize;
-			static mut _core1_stack_len: usize;
+	unsafe {
+		for b in super::CORE1_STACK.iter_mut() {
+			*b = super::CORE1_STACK_PAINT_WORD;
 		}
-		core::slice::from_raw_parts_mut(
-			&mut _core1_stack_bottom as *mut _,
-			&mut _core1_stack_len as *const _ as usize / core::mem::size_of::<usize>(),
-		)
-	};
-
-	for b in core1_stack.iter_mut() {
-		*b = super::CORE1_STACK_PAINT_WORD;
 	}
 
 	debug!(
 		"Core 1 stack: {:08x}, {} bytes",
-		core1_stack.as_ptr(),
-		core1_stack.len()
+		unsafe { super::CORE1_STACK.as_ptr() },
+		unsafe { super::CORE1_STACK.len() * core::mem::size_of::<usize>() }
 	);
 
 	// No-one else is looking at this right now.
@@ -1053,7 +1044,13 @@ pub fn init(
 		TEXT_COLOUR_LOOKUP.init(&VIDEO_PALETTE);
 	}
 
-	multicore_launch_core1_with_stack(core1_main, core1_stack, ppb, fifo, psm);
+	multicore_launch_core1_with_stack(
+		core1_main,
+		unsafe { &mut super::CORE1_STACK },
+		ppb,
+		fifo,
+		psm,
+	);
 
 	debug!("Core 1 running");
 }


### PR DESCRIPTION
I observed in `probe-run` output that we were using all 4096 bytes of our allocated stack region. Adding the painting and measurement code shows that:

* Core 0 uses 4372 bytes peak
* Core 1 uses 312 bytes peak

Thus I upgrade Core 0 to have an 8 KiB stack - stealing the top 4 KiB of the striped region and moving all the BIOS global variables down, and also reducing the TPA by 4 KiB.

Technically we weren't damaging any globals because the 24 KiB block allocated for them had about 900 bytes unused. But we were asking for trouble.

This also led to me finding a bug in probe-run, where it doesn't understand that a stack can span across multiple contiguous memory regions. I raised that as https://github.com/knurling-rs/probe-run/issues/415
