### PR TITLE
Update to published BMC crates.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,8 +531,9 @@ checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "neotron-bmc-commands"
-version = "0.1.0"
-source = "git+https://github.com/neotron-compute/neotron-bmc?tag=v0.5.2#bb08ff2476058e9029a45fdda26f252285f10ddf"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6efa49a652e9172a28e0fecbf99f21ae7b320931fcef3a2638c8870428cadc01"
 dependencies = [
  "num_enum",
 ]
@@ -540,7 +541,8 @@ dependencies = [
 [[package]]
 name = "neotron-bmc-protocol"
 version = "0.1.0"
-source = "git+https://github.com/neotron-compute/neotron-bmc?tag=v0.5.2#bb08ff2476058e9029a45fdda26f252285f10ddf"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff9228d7b028c0056fd225cf3c11533e7548638f2c5822cee10e94ca2c71e718"
 dependencies = [
  "defmt",
  "num_enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,9 @@ pio-proc = "0.2"
 # Hardware locks for sharing data with interrupts
 critical-section = "1.0"
 # Commands for talking to a Neotron BMC. The tag is for the repo as a whole, of which the commands crate is a small part.
-neotron-bmc-commands = { version = "0.1.0", git = "https://github.com/neotron-compute/neotron-bmc", tag = "v0.5.2" }
+neotron-bmc-commands = { version = "0.2.0" }
 # Protocol for talking to a Neotron BMC. The tag is for the repo as a whole, of which the protocol crate is a small part.
-neotron-bmc-protocol = { version = "0.1.0", git = "https://github.com/neotron-compute/neotron-bmc", tag = "v0.5.2", features = [
-    "defmt"
-] }
+neotron-bmc-protocol = { version = "0.1.0", features = ["defmt"] }
 # Time and frequency related functions
 fugit = "0.3"
 # PS/2 scancode decoding

--- a/src/main.rs
+++ b/src/main.rs
@@ -1173,18 +1173,14 @@ impl Hardware {
 	fn play_startup_tune(&mut self) -> Result<(), ()> {
 		// (delay (ms), command, data)
 		let seq: &[(u16, Command, u8)] = &[
-			// NB: Due to a BMC bug, this sets the high period
 			(0, Command::SpeakerPeriodLow, 137),
-			// NB: Due to a BMC bug, this sets the low period
 			(0, Command::SpeakerPeriodHigh, 0),
 			(0, Command::SpeakerDutyCycle, 127),
 			// This triggers the beep to occur
 			(70, Command::SpeakerDuration, 7),
-			// NB: Due to a BMC bug, this sets the high period
 			(0, Command::SpeakerPeriodLow, 116),
 			// This triggers the beep to occur
 			(70, Command::SpeakerDuration, 7),
-			// NB: Due to a BMC bug, this sets the high period
 			(0, Command::SpeakerPeriodLow, 97),
 			// This triggers the beep to occur
 			(70, Command::SpeakerDuration, 7),


### PR DESCRIPTION
Use published crates for talking to the BMC.

Also, the bug with the speaker registers is not where I thought it was.