### PR TITLE
Update to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,19 @@ In this repository, changes are made in branches which are merged into **develop
 
 * None
 
+## v0.6.0 ([Source](https://github.com/neotron-compute/neotron-pico-bios/tree/v0.6.0) | [Release](https://github.com/neotron-compute/neotron-pico-bios/release/tag/v0.6.0))
+
+* Use OS 0.5.0
+* Implement reboot support
+* Hard reboot system if we detect only Core 0 has restarted - should fix odd
+  video issue after flashing
+* Updated to neotron-common-bios 0.11.0
+* Changed the VGA palette to match as required in neotron-common-bios 0.10.0
+* Updated flashing instructions
+
 ## v0.5.2 ([Source](https://github.com/neotron-compute/neotron-pico-bios/tree/v0.5.2) | [Release](https://github.com/neotron-compute/neotron-pico-bios/release/tag/v0.5.2))
 
-* Updated to neotron-common-bios 0.10.0, and changed the VGA palette to match
+* Updated to neotron-common-bios 0.9.0
 * Use published neotron-bmc-protocol and neotron-bmc-commands crates
 * Clarify how BMC speaker works
 * Add ANSI art boot-up logo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,7 +567,7 @@ checksum = "d37886e73d87732421aaf5da617eead9d69a7daf6b0d059780f76157d9ce5372"
 
 [[package]]
 name = "neotron-pico-bios"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "atomic-polyfill 1.0.2",
  "cortex-m",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 readme = "README.md"
 license = "GPL-3.0-or-later"
 name = "neotron-pico-bios"
-version = "0.5.2"
+version = "0.6.0"
 
 [dependencies]
 # Useful Cortex-M specific functions (e.g. SysTick)


### PR DESCRIPTION
* Use OS 0.5.0
* Implement reboot support
* Hard reboot system if we detect only Core 0 has restarted - should fix odd video issue after flashing
* Updated to neotron-common-bios 0.11.0
* Changed the VGA palette to match as required in neotron-common-bios 0.10.0
* Updated flashing instructions