### PR TITLE
Update embedded-sdmmc to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,13 +289,14 @@ dependencies = [
 
 [[package]]
 name = "embedded-sdmmc"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4d14180a76a8af24a45a0e1a4f9c97491b05a3b962d59d5e4ce0e6ab103736"
+checksum = "3778099e48fedd6b81048e1d84f60db663124f5c6e22fcef495040b9d51fe06a"
 dependencies = [
  "byteorder",
  "defmt",
  "embedded-hal",
+ "heapless",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ shared-bus = "0.2"
 # Gets us compare-swap atomic operations
 atomic-polyfill = "1.0.2"
 # SD Card driver
-embedded-sdmmc = { version = "0.5", default-features = false, features = [
+embedded-sdmmc = { version = "0.6", default-features = false, features = [
     "defmt-log"
 ] }
 # CODEC register control


### PR DESCRIPTION
Just a bump on the embedded-sdmmc crate. Lets us control how many retries we do on the SD card to acquire it.